### PR TITLE
Add automatic sitemap discovery from website URL

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -77,11 +77,6 @@ function octopus_ai_handle_pdf_upload() {
     if (!file_exists($upload_path)) wp_mkdir_p($upload_path);
     if (!file_exists($chunks_dir)) wp_mkdir_p($chunks_dir);
 
-    // Verwijder oude chunks
-    foreach (glob($chunks_dir . '*.txt') as $old_chunk) {
-        unlink($old_chunk);
-    }
-
     $files = $_FILES['octopus_ai_pdf_upload'];
 
     foreach ($files['name'] as $index => $name) {
@@ -94,9 +89,14 @@ function octopus_ai_handle_pdf_upload() {
                 $chunker = new Chunker();
                 $chunks = $chunker->chunkPdfWithMetadata($filepath, $slug);
 
+                // verwijder bestaande chunks voor dit PDF-bestand
+                foreach (glob($chunks_dir . $slug . '_chunk_*.txt') as $old) {
+                    unlink($old);
+                }
+
                 foreach ($chunks as $i => $chunk) {
                     $meta = $chunk['metadata'];
-                    $file = $chunks_dir . 'chunk_' . ($i + 1) . '.txt';
+                    $file = $chunks_dir . $slug . '_chunk_' . ($i + 1) . '.txt';
 
                     $text = $chunk['content'] . PHP_EOL .
                         '##source_title:' . $meta['source_title'] . PHP_EOL .
@@ -127,9 +127,25 @@ function octopus_ai_handle_delete_file() {
     }
 
     $upload_dir = wp_upload_dir();
-    $file_path = trailingslashit($upload_dir['basedir']) . 'octopus-chatbot/' . basename($_GET['file']);
+    $safe_file = basename($_GET['file']);
+    $file_path = trailingslashit($upload_dir['basedir']) . 'octopus-chatbot/' . $safe_file;
+    $chunks_dir = trailingslashit($upload_dir['basedir']) . 'octopus-ai-chunks/';
 
     if (file_exists($file_path)) {
+        $ext = pathinfo($safe_file, PATHINFO_EXTENSION);
+        if ($ext === 'pdf') {
+            $slug = basename($safe_file, '.pdf');
+            foreach (glob($chunks_dir . $slug . '_chunk_*.txt') as $chunk) {
+                unlink($chunk);
+            }
+        } elseif ($ext === 'xml') {
+            $urls = octopus_ai_parse_sitemap($file_path);
+            if ($urls) {
+                $parser = new \OctopusAI\Includes\SitemapParser();
+                $parser->deleteChunksForUrls($urls);
+            }
+        }
+
         unlink($file_path);
         wp_redirect(add_query_arg('delete', 'success', admin_url('admin.php?page=octopus-ai-chatbot')));
     } else {
@@ -152,12 +168,27 @@ function octopus_ai_handle_bulk_delete() {
     $files_to_delete = isset($_POST['octopus_ai_files']) ? (array) $_POST['octopus_ai_files'] : array();
     $upload_dir = wp_upload_dir();
     $upload_path = trailingslashit($upload_dir['basedir']) . 'octopus-chatbot/';
+    $chunks_dir = trailingslashit($upload_dir['basedir']) . 'octopus-ai-chunks/';
 
     $deleted_count = 0;
     foreach ($files_to_delete as $filename) {
         $safe_name = basename($filename);
         $file_path = $upload_path . $safe_name;
         if (file_exists($file_path)) {
+            $ext = pathinfo($safe_name, PATHINFO_EXTENSION);
+            if ($ext === 'pdf') {
+                $slug = basename($safe_name, '.pdf');
+                foreach (glob($chunks_dir . $slug . '_chunk_*.txt') as $chunk) {
+                    unlink($chunk);
+                }
+            } elseif ($ext === 'xml') {
+                $urls = octopus_ai_parse_sitemap($file_path);
+                if ($urls) {
+                    $parser = new \OctopusAI\Includes\SitemapParser();
+                    $parser->deleteChunksForUrls($urls);
+                }
+            }
+
             unlink($file_path);
             $deleted_count++;
         }
@@ -312,6 +343,9 @@ function octopus_ai_settings_page() {
 
         <?php if (isset($_GET['upload']) && $_GET['upload'] === 'success'): ?>
             <div class="notice notice-success is-dismissible"><p>PDF's succesvol geüpload en verwerkt.</p></div>
+        <?php endif; ?>
+        <?php if (isset($_GET['upload']) && $_GET['upload'] === 'sitemap' && isset($_GET['found']) && isset($_GET['pages'])): ?>
+            <div class="notice notice-success is-dismissible"><p><?php echo intval($_GET['found']); ?> URL(s) gevonden en <?php echo intval($_GET['pages']); ?> pagina's gecrawld.</p></div>
         <?php endif; ?>
         <?php if (isset($_GET['delete']) && $_GET['delete'] === 'success'): ?>
             <div class="notice notice-success is-dismissible"><p>Bestand succesvol verwijderd.</p></div>
@@ -516,6 +550,13 @@ function octopus_ai_settings_page() {
         <input type="url" name="sitemap_url" value="<?php echo esc_attr(get_option('octopus_ai_sitemap_url', '')); ?>" style="width:400px;" placeholder="https://example.com/sitemap.xml" />
         <?php submit_button('💾 Sitemap opslaan'); ?>
     </form>
+
+    <form method="post" action="<?php echo admin_url('admin-post.php'); ?>" style="margin-top:15px;">
+        <?php wp_nonce_field('octopus_ai_auto_sitemap', 'octopus_ai_auto_sitemap_nonce'); ?>
+        <input type="hidden" name="action" value="octopus_ai_auto_fetch_sitemap">
+        <input type="url" name="octopus_ai_site_url" style="width:400px;" placeholder="https://example.com" required />
+        <?php submit_button('🔎 Zoek sitemap automatisch', 'secondary'); ?>
+    </form>
 </div>
 
 
@@ -531,8 +572,6 @@ if (file_exists($sitemap_path)) {
     echo '<p><strong>📄 Huidige sitemap:</strong> <a href="' . esc_url($upload_url . 'sitemap.xml') . '" target="_blank">Bekijk sitemap.xml</a></p>';
 }
 
-$sitemap_urls = get_option('octopus_ai_sitemap_urls', []);
-
 require_once plugin_dir_path(__FILE__) . '../includes/sitemap-parser.php';
 $parser = new \OctopusAI\Includes\SitemapParser();
 
@@ -546,13 +585,7 @@ if (isset($_GET['sitemap_debug'])) {
     echo '</ul>';
 }
 
-if (isset($_GET['crawl']) && $_GET['crawl'] === 'now') {
-    $count = $parser->fetchAndSaveHtmlFromUrls(0);
-    echo "<div class='updated'><p><strong>$count pagina's</strong> gecrawld en opgeslagen in chunks-folder.</p></div>";
-}
-
-echo '<p><a href="' . esc_url(add_query_arg('sitemap_debug', '1')) . '" class="button">🔍 Toon sitemap-URL’s</a> ';
-echo '<a href="' . esc_url(add_query_arg('crawl', 'now')) . '" class="button button-primary">🌐 Crawlen & opslaan</a></p>';
+echo '<p><a href="' . esc_url(add_query_arg('sitemap_debug', '1')) . '" class="button">🔍 Toon sitemap-URL’s</a></p>';
 ?>
 
 <hr>
@@ -653,7 +686,7 @@ if (file_exists($chunk_dir)) {
 <script>
 document.addEventListener('DOMContentLoaded', function () {
     const url = new URL(window.location);
-    const paramsToRemove = ['upload', 'delete', 'bulk_delete', 'chunks_deleted', 'chunks_cleared', 'sitemap_debug', 'crawl'];
+    const paramsToRemove = ['upload', 'delete', 'bulk_delete', 'chunks_deleted', 'chunks_cleared', 'sitemap_debug', 'pages'];
 
     let shouldUpdate = false;
     for (const param of paramsToRemove) {
@@ -685,7 +718,7 @@ function toggleSection(header) {
             row.style.display = this.value === 'selected' ? '' : 'none';
         });
     </script>
-<?php if (isset($_GET['upload']) || isset($_GET['crawl']) || isset($_GET['sitemap_debug'])): ?>
+<?php if (isset($_GET['upload']) || isset($_GET['sitemap_debug'])): ?>
 <script>
     document.addEventListener('DOMContentLoaded', function () {
         const el = document.getElementById('sitemap-zone');

--- a/admin/upload-page.php
+++ b/admin/upload-page.php
@@ -36,8 +36,13 @@ function octopus_ai_pdf_upload_page() {
                     wp_mkdir_p($chunks_dir);
                 }
 
+                $slug = basename($file_path, '.pdf');
+                foreach (glob($chunks_dir . $slug . '_chunk_*.txt') as $old) {
+                    unlink($old);
+                }
+
                 foreach ($chunks as $index => $chunk) {
-                    $chunk_file = $chunks_dir . basename($file_path) . '_chunk_' . $index . '.txt';
+                    $chunk_file = $chunks_dir . $slug . '_chunk_' . $index . '.txt';
                     file_put_contents($chunk_file, $chunk);
                 }
 

--- a/includes/sitemap-parser.php
+++ b/includes/sitemap-parser.php
@@ -41,41 +41,63 @@ class SitemapParser {
 
     /**
      * ✅ Haal content op van URL's en bewaar als chunks in .txt-bestanden
+     *
+     * @param int   $limit Max aantal te verwerken URL's (0 = onbeperkt)
+     * @param array|null $urls Optionele lijst van URL's om te verwerken
      */
-    public function fetchAndSaveHtmlFromUrls($limit = 0) {
-    $upload_dir = wp_upload_dir();
-    $output_dir = trailingslashit($upload_dir['basedir']) . 'octopus-ai-chunks/';
-    if (!file_exists($output_dir)) wp_mkdir_p($output_dir);
+    public function fetchAndSaveHtmlFromUrls($limit = 0, $urls = null) {
+        $upload_dir = wp_upload_dir();
+        $output_dir = trailingslashit($upload_dir['basedir']) . 'octopus-ai-chunks/';
+        if (!file_exists($output_dir)) wp_mkdir_p($output_dir);
 
-    $urls = $this->getUrlsFromSitemap();
-    $count = 0;
+        if ($urls === null) {
+            $urls = $this->getUrlsFromSitemap();
+        }
 
-    foreach ($urls as $url) {
-        if ($limit > 0 && $count >= $limit) break; // enkel als limiet > 0
+        $count = 0;
 
-        $response = wp_remote_get($url);
-        if (is_wp_error($response)) continue;
+        foreach ($urls as $url) {
+            if ($limit > 0 && $count >= $limit) break; // enkel als limiet > 0
 
-        $html = wp_remote_retrieve_body($response);
-        if (!$html) continue;
+            $response = wp_remote_get($url);
+            if (is_wp_error($response)) continue;
 
-        libxml_use_internal_errors(true);
-        $dom = new \DOMDocument();
-        @$dom->loadHTML($html);
-        libxml_clear_errors();
+            $html = wp_remote_retrieve_body($response);
+            if (!$html) continue;
 
-        $xpath = new \DOMXPath($dom);
-        $mainNode = $xpath->query('//main')->item(0) ?? $xpath->query('//body')->item(0);
-        if (!$mainNode) continue;
+            libxml_use_internal_errors(true);
+            $dom = new \DOMDocument();
+            @$dom->loadHTML($html);
+            libxml_clear_errors();
 
-        $text = trim($mainNode->textContent);
-        if (strlen($text) < 50) continue;
+            $xpath = new \DOMXPath($dom);
+            $mainNode = $xpath->query('//main')->item(0) ?? $xpath->query('//body')->item(0);
+            if (!$mainNode) continue;
 
-        $slug = sanitize_title(basename(parse_url($url, PHP_URL_PATH))) ?: 'pagina-' . $count;
-        file_put_contents($output_dir . 'sitemap_' . $slug . '.txt', $text);
-        $count++;
+            $text = trim($mainNode->textContent);
+            if (strlen($text) < 50) continue;
+
+            $slug = sanitize_title(basename(parse_url($url, PHP_URL_PATH))) ?: 'pagina-' . $count;
+            file_put_contents($output_dir . 'sitemap_' . $slug . '.txt', $text);
+            $count++;
+        }
+
+        return $count;
     }
 
-    return $count;
-}
+    /**
+     * 🧹 Verwijder chunk-bestanden op basis van een lijst URL's
+     */
+    public function deleteChunksForUrls(array $urls) {
+        $upload_dir = wp_upload_dir();
+        $chunk_dir = trailingslashit($upload_dir['basedir']) . 'octopus-ai-chunks/';
+
+        foreach ($urls as $index => $url) {
+            $slug = sanitize_title(basename(parse_url($url, PHP_URL_PATH))) ?: 'pagina-' . $index;
+            $file = $chunk_dir . 'sitemap_' . $slug . '.txt';
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- allow admins to auto-discover a website's sitemap via robots.txt or default paths
- add admin UI for providing a base URL and auto-fetching its sitemap
- recursively parse sitemap indexes to gather URLs from nested sitemaps
- immediately chunk sitemap URLs or PDFs and remove chunks when their source files are deleted

## Testing
- `php -l admin/sitemap-handler.php`
- `php -l admin/settings-page.php`
- `php -l includes/sitemap-parser.php`
- `php -l admin/upload-page.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_b_68944b975b1483329b77e7045a07c6d3