### PR TITLE
Add subtle pulse animation to chat toggle

### DIFF
--- a/assets/css/chatbot.css
+++ b/assets/css/chatbot.css
@@ -21,6 +21,7 @@
     cursor: pointer;
     z-index: 9999;
     transition: transform 0.2s ease;
+    animation: pulse 4s ease-in-out infinite;
 }
 
 #octopus-chat-toggle:hover {
@@ -30,6 +31,31 @@
 #octopus-chat-toggle img {
     width: 40px;
     height: 40px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    #octopus-chat-toggle {
+        animation: none;
+    }
+}
+
+#octopus-chat-toggle.pop-highlight {
+    animation: pop 0.3s ease-out, pulse 4s ease-in-out infinite;
+}
+
+#octopus-chat-toggle.pop-highlight::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 80px;
+    height: 80px;
+    transform: translate(-50%, -50%) scale(1);
+    border: 2px solid var(--primary-color);
+    border-radius: 50%;
+    opacity: 0;
+    animation: popLines 0.6s ease-out;
+    pointer-events: none;
 }
 
 /* ==========================================================================
@@ -352,6 +378,17 @@
     0%   { transform: scale(1); }
     50%  { transform: scale(1.05); }
     100% { transform: scale(1); }
+}
+
+@keyframes pop {
+    0%   { transform: scale(1); }
+    50%  { transform: scale(1.2); }
+    100% { transform: scale(1); }
+}
+
+@keyframes popLines {
+    0%   { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+    100% { opacity: 0; transform: translate(-50%, -50%) scale(1.6); }
 }
 
 

--- a/assets/js/chatbot.js
+++ b/assets/js/chatbot.js
@@ -10,6 +10,17 @@ document.addEventListener('DOMContentLoaded', function () {
     chatbot.id = 'octopus-chatbot';
     document.body.appendChild(chatbot);
 
+    const path = window.location.pathname;
+    const isHome = path === '/' || path === '/index.php' || path === '/fr/';
+    if (isHome) {
+        setTimeout(() => {
+            if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+                toggleButton.classList.add('pop-highlight');
+                setTimeout(() => toggleButton.classList.remove('pop-highlight'), 800);
+            }
+        }, 2000);
+    }
+
     const settings = octopus_ai_chatbot_vars;
 const fallbackTrigger = settings.i18n.fallback_trigger || "Sorry, daar kan ik je niet mee helpen.";
 


### PR DESCRIPTION
## Summary
- animate the chatbot toggle with a gentle pulse to signal availability
- highlight the toggle on the homepage with a delayed pop outline after load

## Testing
- `composer validate --no-interaction`


------
https://chatgpt.com/codex/tasks/task_b_68b062e6a64c8332858200bde67e53ad