### PR TITLE
feat: add glass logo backdrop

### DIFF
--- a/assets/css/chatbot.css
+++ b/assets/css/chatbot.css
@@ -103,6 +103,11 @@
     justify-content: space-between;
 }
 
+.chat-header-inner {
+    display: flex;
+    align-items: center;
+}
+
 #chat-header .chat-header-title {
     flex-grow: 1;
     text-align: center;
@@ -113,7 +118,19 @@
 
 #chat-header img {
     height: 24px;
-    max-width: 28px;
+    max-width: 24px;
+}
+
+.chat-logo-glass {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: rgba(255,255,255,0.6);
+    -webkit-backdrop-filter: blur(4px);
+    backdrop-filter: blur(4px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
     margin-right: 10px;
 }
 

--- a/assets/js/chatbot.js
+++ b/assets/js/chatbot.js
@@ -41,7 +41,9 @@ if (!lang || lang === '') {
     chatbot.innerHTML = `
         <div id="chat-header" style="background-color:${settings.primary_color};">
             <div class="chat-header-inner">
-                <img src="${settings.logo_url}" alt="Logo" class="chat-logo" style="height: 24px; max-width: 28px; margin-right: 10px;">
+                <div class="chat-logo-glass">
+                    <img src="${settings.logo_url}" alt="Logo" class="chat-logo">
+                </div>
                 <span class="chat-header-title">${settings.brand_name || 'AI Chatbot'}</span>
             </div>
             <button id="chat-close" aria-label="Sluiten" class="chat-close-button">&times;</button>


### PR DESCRIPTION
## Summary
- wrap chat header logo in a circular glass-style container for consistent visibility
- align logo container with header text via flexbox

## Testing
- `npm test` (fails: package.json missing)
- `composer test` (fails: command not defined)


------
https://chatgpt.com/codex/tasks/task_b_68b150652f1083329c7f6420ed76cd76