### PR TITLE
Handle Unicode escape sequences and improve FR fallback label

### DIFF
--- a/includes/api-handler.php
+++ b/includes/api-handler.php
@@ -242,8 +242,8 @@ if (!$answer) {
     return new WP_Error('api_error', 'Fout van OpenAI: ' . $error_message);
 }
 
-// ✅ Unicode-decoding voor \uXXXX (zoals \u00e9 → é)
-$answer = preg_replace_callback('/\\\\u([0-9a-fA-F]{4})/', function ($matches) {
+// ✅ Unicode-decoding voor uXXXX of \uXXXX (zoals u00e9 → é)
+$answer = preg_replace_callback('/(?:\\\\u|\\?u)([0-9a-fA-F]{4})/', function ($matches) {
     $hex = $matches[1];
     $bin = pack('H*', $hex);
     return mb_convert_encoding($bin, 'UTF-8', 'UTF-16BE');
@@ -298,15 +298,14 @@ if (
     }
     $keyword = octopus_ai_extract_keyword($message);
     if ($keyword) {
-    $lang = (strpos($_SERVER['REQUEST_URI'], '/fr') !== false) ? 'FR' : 'NL';
-$zoeklink = "https://login.octopus.be/manual/{$lang}/hmftsearch.htm?zoom_query=" . rawurlencode($keyword);
+        $zoeklink = "https://login.octopus.be/manual/{$lang}/hmftsearch.htm?zoom_query=" . rawurlencode($keyword);
 
-if (empty(trim($answer))) {
-    $answer = $fallback;
-}
+        if (empty(trim($answer))) {
+            $answer = $fallback;
+        }
 
         $label = ($lang === 'FR') ? 'Voir aussi dans la documentation' : 'Bekijk mogelijke info in de handleiding';
-$answer .= "\n\n[$label]($zoeklink)";
+        $answer .= "\n\n[$label]($zoeklink)";
     }
 }
 

--- a/octopus-ai-chatbot.php
+++ b/octopus-ai-chatbot.php
@@ -51,9 +51,9 @@ function octopus_ai_enqueue_frontend_assets() {
     wp_enqueue_style('octopus-ai-chatbot-style', plugin_dir_url(__FILE__) . 'assets/css/chatbot.css', array(), '1.0');
     wp_enqueue_script('octopus-ai-chatbot-script', plugin_dir_url(__FILE__) . 'assets/js/chatbot.js', array('jquery'), '1.0', true);
 
-    $is_french  = preg_match('#^/fr(/|$)#', $_SERVER['REQUEST_URI']);
     $lang_header = strtolower($_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '');
-    $lang_code  = ($is_french || strpos($lang_header, 'fr') === 0) ? 'FR' : 'NL';
+    $is_french  = preg_match('#/fr(/|$)#', $_SERVER['REQUEST_URI']) || strpos($lang_header, 'fr') === 0;
+    $lang_code  = $is_french ? 'FR' : 'NL';
 
 
     wp_localize_script('octopus-ai-chatbot-script', 'octopus_ai_chatbot_vars', array(


### PR DESCRIPTION
## Summary
- Decode Unicode escape sequences like `u00e9` in AI responses
- Respect language detection when adding fallback manual links
- Detect French via URL or browser settings for localized UI strings

## Testing
- `php -l includes/api-handler.php`
- `php -l octopus-ai-chatbot.php`


------
https://chatgpt.com/codex/tasks/task_b_68b1522f91d083329e2b42889d85a64c