### PR TITLE
Append direct manual link when available

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -87,7 +87,8 @@ function octopus_ai_handle_pdf_upload() {
             if (move_uploaded_file($files['tmp_name'][$index], $filepath)) {
                 $slug = basename($filename, '.pdf');
                 $chunker = new Chunker();
-                $chunks = $chunker->chunkPdfWithMetadata($filepath, $slug);
+                $file_url = trailingslashit($upload_dir['baseurl']) . 'octopus-chatbot/' . $filename;
+                $chunks = $chunker->chunkPdfWithMetadata($filepath, $slug, $file_url);
 
                 // verwijder bestaande chunks voor dit PDF-bestand
 
@@ -107,6 +108,7 @@ function octopus_ai_handle_pdf_upload() {
                             'page_slug'     => $meta['page_slug'] ?? '',
                             'original_page' => $meta['original_page'] ?? '',
                             'section_title' => $meta['section_title'] ?? '',
+                            'source_url'    => $meta['source_url'] ?? '',
                         ],
                     ];
                     file_put_contents($file, wp_json_encode($data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));

--- a/includes/pdf-chunker.php
+++ b/includes/pdf-chunker.php
@@ -25,9 +25,10 @@ class Chunker
      *
      * @param string $filePath Volledig pad naar het PDF-bestand.
      * @param string $sourceId Slug of bestandsnaam zonder extensie.
+     * @param string $fileUrl Publieke URL naar het PDF-bestand.
      * @return array
      */
-    public function chunkPdfWithMetadata(string $filePath, string $sourceId): array
+    public function chunkPdfWithMetadata(string $filePath, string $sourceId, string $fileUrl): array
     {
         $parser = new Parser();
         $pdf = $parser->parseFile($filePath);
@@ -47,12 +48,13 @@ class Chunker
             $splitChunks = $this->splitTextIntoChunks($text, $this->chunkSize);
             foreach ($splitChunks as $chunkText) {
                 $chunks[] = [
-                    'content' => $chunkText,
+                    'content'  => $chunkText,
                     'metadata' => [
-                        'page_slug' => $pageSlug,
-                        'source_title' => $sourceTitle,
+                        'page_slug'     => $pageSlug,
+                        'source_title'  => $sourceTitle,
                         'original_page' => $pageNumber,
                         'section_title' => $sectionTitle,
+                        'source_url'    => $fileUrl . '#page=' . $pageNumber,
                     ],
                 ];
             }


### PR DESCRIPTION
## Summary
- capture first valid doc or website link from chunk metadata
- append direct manual link to chatbot responses when available
- retain search fallback if no precise link is found
- store PDF page URLs in chunk metadata for precise manual links

## Testing
- `php -l includes/api-handler.php`
- `php -l includes/pdf-chunker.php`
- `php -l admin/settings-page.php`


------
https://chatgpt.com/codex/tasks/task_b_68b15b2eb15883328e9c71b7db1fadfa