### PR TITLE
Improve source material strategy UI and exclusivity

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -4,6 +4,7 @@ if (!defined('ABSPATH')) exit;
 
 
 use OctopusAI\Includes\Chunker;
+use OctopusAI\Includes\SitemapParser;
 
 // --- ADMIN MENU ---
 add_action('admin_menu', 'octopus_ai_add_admin_menu');
@@ -54,11 +55,23 @@ function octopus_ai_register_settings() {
     register_setting('octopus_ai_settings_group', 'octopus_ai_selected_pages', function($value){
         return array_map('intval', (array) $value);
     });
+    register_setting('octopus_ai_settings_group', 'octopus_ai_source_strategy', 'octopus_ai_sanitize_source_strategy');
     register_setting('octopus_ai_settings_group', 'octopus_ai_manual_mode', 'octopus_ai_sanitize_manual_mode');
     register_setting('octopus_ai_settings_group', 'octopus_ai_manual_base_url_nl', 'octopus_ai_sanitize_manual_url');
     register_setting('octopus_ai_settings_group', 'octopus_ai_manual_base_url_fr', 'octopus_ai_sanitize_manual_url');
     register_setting('octopus_ai_settings_group', 'octopus_ai_manual_priority_urls_nl', 'octopus_ai_sanitize_manual_url_list');
     register_setting('octopus_ai_settings_group', 'octopus_ai_manual_priority_urls_fr', 'octopus_ai_sanitize_manual_url_list');
+}
+
+function octopus_ai_sanitize_source_strategy($value) {
+    $allowed = ['manual_upload', 'sitemap_online', 'live_manual'];
+    $value = is_string($value) ? strtolower($value) : '';
+
+    if (!in_array($value, $allowed, true)) {
+        return 'manual_upload';
+    }
+
+    return $value;
 }
 
 function octopus_ai_sanitize_manual_mode($value) {
@@ -275,11 +288,25 @@ function octopus_ai_settings_page() {
     $api_key = get_option('octopus_ai_api_key');
     $masked_key = $api_key ? substr($api_key, 0, 5) . str_repeat('*', strlen($api_key) - 10) . substr($api_key, -5) : '';
     $selected_model = get_option('octopus_ai_model', 'gpt-4.1-mini');
+    $source_strategy = get_option('octopus_ai_source_strategy', 'manual_upload');
     $manual_mode = get_option('octopus_ai_manual_mode', 'hybrid');
     $manual_base_nl = get_option('octopus_ai_manual_base_url_nl', '');
     $manual_base_fr = get_option('octopus_ai_manual_base_url_fr', '');
     $manual_priority_nl = get_option('octopus_ai_manual_priority_urls_nl', '');
     $manual_priority_fr = get_option('octopus_ai_manual_priority_urls_fr', '');
+    $saved_sitemap_url = get_option('octopus_ai_sitemap_url', '');
+
+    if (!class_exists(SitemapParser::class)) {
+        require_once plugin_dir_path(__FILE__) . '../includes/sitemap-parser.php';
+    }
+
+    $parser = new SitemapParser();
+    $sitemap_path = $upload_path . 'sitemap.xml';
+
+    if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sitemap_url'])) {
+        update_option('octopus_ai_sitemap_url', esc_url_raw($_POST['sitemap_url']));
+        echo '<div class="notice notice-success is-dismissible"><p>Sitemap-URL opgeslagen.</p></div>';
+    }
     ?>
     <style>
     .octopus-settings .form-table th {
@@ -299,38 +326,6 @@ function octopus_ai_settings_page() {
         font-size: 20px;
         color: #0f6c95;
     }
-
-    .collapsible-heading {
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    background: #f3f4f6;
-    padding: 10px;
-    border-left: 4px solid var(--primary-color, #0f6c95);
-    font-size: 16px;
-    margin-top: 40px;
-    border-radius: 4px;
-}
-
-.collapsible-heading .toggle-arrow {
-    font-size: 14px;
-    margin-left: 10px;
-    transition: transform 0.3s ease;
-}
-
-.collapsible-heading.collapsed .toggle-arrow {
-    transform: rotate(-90deg);
-}
-
-.collapsible-content {
-    display: block;
-    margin-top: 10px;
-    transition: all 0.3s ease;
-}
-.collapsible-content.hidden {
-    display: none;
-}
 
     .octopus-settings input[type="text"],
     .octopus-settings input[type="url"],
@@ -406,6 +401,59 @@ function octopus_ai_settings_page() {
     margin-bottom: 10px;
 }
 
+.source-mode-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 15px;
+    margin-top: 15px;
+}
+
+.source-mode-card {
+    border: 1px solid #d8dee4;
+    border-radius: 10px;
+    padding: 15px;
+    background: #fff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.source-mode-card.is-active {
+    border-color: var(--primary-color, #0f6c95);
+    box-shadow: 0 4px 14px rgba(15, 108, 149, 0.15);
+}
+
+.source-mode-card input[type="radio"] {
+    margin-right: 6px;
+}
+
+.source-mode-card small {
+    display: inline-block;
+    background: #eef6fb;
+    color: #0f6c95;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+}
+
+.source-mode-details {
+    margin-top: 30px;
+}
+
+.source-mode-panel {
+    display: none;
+    margin-bottom: 30px;
+}
+
+.source-mode-panel.is-active {
+    display: block;
+}
+
+.source-mode-panel h3 {
+    margin-top: 0;
+}
+
 </style>
 
     <div class="wrap octopus-settings">
@@ -423,8 +471,9 @@ function octopus_ai_settings_page() {
             <div class="notice notice-success is-dismissible"><p>Bestand succesvol verwijderd.</p></div>
         <?php endif; ?>
 
-        <form method="post" action="options.php">
+        <form id="octopus-ai-settings-form" method="post" action="options.php">
             <?php settings_fields('octopus_ai_settings_group'); ?>
+            <input type="hidden" name="octopus_ai_manual_mode" id="octopus_ai_manual_mode_hidden" value="<?php echo esc_attr($manual_mode); ?>">
 
             <h2>🔐 API-instellingen</h2>
             <table class="form-table">
@@ -563,28 +612,48 @@ function octopus_ai_settings_page() {
                 </tr>
             </table>
 
-            <h2>📄 Documentatiebron</h2>
-            <p class="section-description">Bepaal of de chatbot lokale chunks gebruikt, live de handleiding ophaalt of beide combineert.</p>
+            <h2>📚 Bronmateriaal</h2>
+            <p class="section-description">Kies één bron. De chatbot zal uitsluitend deze methode gebruiken om context en links te tonen.</p>
+            <?php
+            $source_cards = [
+                'manual_upload' => [
+                    'title'       => 'Manueel uploaden',
+                    'description' => 'Upload PDF- of sitemapbestanden en bouw zelf chunks op.',
+                    'badge'       => 'Offline',
+                    'cta'         => 'Gebruik uitsluitend geüploade bestanden.',
+                ],
+                'sitemap_online' => [
+                    'title'       => 'Online sitemap gebruiken',
+                    'description' => 'Zoek of bewaar een sitemap-URL en laat Octopus de inhoud crawlen.',
+                    'badge'       => 'Automatisch',
+                    'cta'         => 'Gebruik uitsluitend de gevonden sitemap.',
+                ],
+                'live_manual' => [
+                    'title'       => 'Live handleiding',
+                    'description' => 'Haalt realtime informatie uit de handleiding en toont exacte links.',
+                    'badge'       => 'Realtime',
+                    'cta'         => 'Gebruik enkel live opgehaalde pagina’s.',
+                ],
+            ];
+            ?>
+            <div class="source-mode-grid">
+                <?php foreach ($source_cards as $value => $card): ?>
+                    <div class="source-mode-card <?php echo $source_strategy === $value ? 'is-active' : ''; ?>" data-target="<?php echo esc_attr($value); ?>">
+                        <div>
+                            <label style="display:flex;align-items:center;gap:8px;font-weight:600;">
+                                <input type="radio" name="octopus_ai_source_strategy" value="<?php echo esc_attr($value); ?>" <?php checked($source_strategy, $value); ?>>
+                                <?php echo esc_html($card['title']); ?>
+                            </label>
+                            <small><?php echo esc_html($card['badge']); ?></small>
+                        </div>
+                        <p><?php echo esc_html($card['description']); ?></p>
+                        <p class="description" style="margin:0;color:#444;"><?php echo esc_html($card['cta']); ?></p>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+
+            <h2 style="margin-top:35px;">📄 Handleiding & voorkeuren</h2>
             <table class="form-table">
-                <tr>
-                    <th>Werking</th>
-                    <td>
-                        <fieldset>
-                            <label style="display:block;margin-bottom:6px;">
-                                <input type="radio" name="octopus_ai_manual_mode" value="local" <?php checked('local', $manual_mode); ?>>
-                                Alleen lokale chunks gebruiken
-                            </label>
-                            <label style="display:block;margin-bottom:6px;">
-                                <input type="radio" name="octopus_ai_manual_mode" value="hybrid" <?php checked('hybrid', $manual_mode); ?>>
-                                Hybride: eerst chunks, aanvullend live handleiding
-                            </label>
-                            <label style="display:block;">
-                                <input type="radio" name="octopus_ai_manual_mode" value="live" <?php checked('live', $manual_mode); ?>>
-                                Alleen live handleiding gebruiken
-                            </label>
-                        </fieldset>
-                    </td>
-                </tr>
                 <tr>
                     <th>Basis URL NL</th>
                     <td>
@@ -680,248 +749,261 @@ function octopus_ai_settings_page() {
 
             <?php submit_button('Instellingen opslaan'); ?>
         </form>
-    </div>
-        <hr>
-
-        <h2 class="collapsible-heading" onclick="toggleSection(this)">
-    🗂️ Geüploade Bestanden <span class="toggle-arrow">▼</span>
-</h2>
-        <div class="collapsible-content hidden">
-
-        <div class="upload-box">
-    <h3>📄 PDF-handleidingen uploaden</h3>
-    <form method="post" action="<?php echo admin_url('admin-post.php'); ?>" enctype="multipart/form-data">
-        <?php wp_nonce_field('octopus_ai_upload_pdf', 'octopus_ai_pdf_nonce'); ?>
-        <input type="hidden" name="action" value="octopus_ai_pdf_upload">
-        <input type="file" name="octopus_ai_pdf_upload[]" accept="application/pdf" multiple required>
-        <?php submit_button('Upload PDF'); ?>
-    </form>
-</div>
-
 
         <?php
-        if (isset($_GET['bulk_delete'])) {
-            echo '<div class="notice notice-success is-dismissible"><p>' . intval($_GET['bulk_delete']) . ' bestand(en) succesvol verwijderd.</p></div>';
-        }
-        if (file_exists($upload_path)) {
-            $files = glob($upload_path . '*');
-            if ($files) {
-                echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '">';
-                wp_nonce_field('octopus_ai_bulk_delete', 'octopus_ai_bulk_delete_nonce');
-                echo '<input type="hidden" name="action" value="octopus_ai_bulk_delete">';
-                echo '<ul>';
-                foreach ($files as $file) {
-                    $filename = basename($file);
-                    $delete_url = wp_nonce_url(admin_url('admin-post.php?action=octopus_ai_delete_file&file=' . urlencode($filename)), 'octopus_ai_delete_file');
-                    echo '<li>';
-                    echo '<label><input type="checkbox" name="octopus_ai_files[]" value="' . esc_attr($filename) . '"> ';
-                    echo '<a href="' . esc_url($upload_url . $filename) . '" target="_blank">' . esc_html($filename) . '</a></label> ';
-                    echo '<a href="' . esc_url($delete_url) . '" style="color:red;margin-left:10px;" onclick="return confirm(\'Weet je zeker dat je dit bestand wilt verwijderen?\');">Verwijderen</a>';
-                    echo '</li>';
-                }
-                echo '</ul>';
-                echo '<p><input type="submit" class="button button-secondary" value="Geselecteerde bestanden verwijderen" onclick="return confirm(\'Weet je zeker dat je deze bestanden wilt verwijderen?\');"></p>';
-                echo '</form>';
-            } else {
-                echo '<p>Er zijn nog geen bestanden geüpload.</p>';
-            }
-        } else {
-            echo '<p>Er zijn nog geen bestanden geüpload.</p>';
-        }
+        $sitemap_dir = trailingslashit($upload_dir['basedir']) . 'octopus-chatbot/';
+        $sitemap_url_base = trailingslashit($upload_dir['baseurl']) . 'octopus-chatbot/';
+        $sitemaps = glob($sitemap_dir . '*.xml');
+        $chunk_dir = trailingslashit($upload_dir['basedir']) . 'octopus-ai-chunks/';
+        $chunk_url = trailingslashit($upload_dir['baseurl']) . 'octopus-ai-chunks/';
+        $shared_active = in_array($source_strategy, ['manual_upload', 'sitemap_online'], true);
         ?>
 
-        <hr>
+        <div class="source-mode-details">
+            <div class="source-mode-panel <?php echo $source_strategy === 'manual_upload' ? 'is-active' : ''; ?>" data-mode="manual_upload">
+                <div class="upload-box">
+                    <h3>📄 PDF-handleidingen uploaden</h3>
+                    <p class="section-description">Upload één of meerdere PDF-bestanden. Elke upload wordt automatisch gechunkt en vormt de enige bron voor antwoorden.</p>
+                    <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" enctype="multipart/form-data">
+                        <?php wp_nonce_field('octopus_ai_upload_pdf', 'octopus_ai_pdf_nonce'); ?>
+                        <input type="hidden" name="action" value="octopus_ai_pdf_upload">
+                        <input type="file" name="octopus_ai_pdf_upload[]" accept="application/pdf" multiple required>
+                        <?php submit_button('Upload PDF'); ?>
+                    </form>
+                </div>
 
-       <div class="upload-box">
-    <h3>🗺️ Sitemap uploaden of via URL</h3>
-    <form method="post" action="<?php echo admin_url('admin-post.php'); ?>" enctype="multipart/form-data" style="margin-bottom: 15px;">
-        <?php wp_nonce_field('octopus_ai_upload_sitemap', 'octopus_ai_sitemap_nonce'); ?>
-        <input type="hidden" name="action" value="octopus_ai_upload_sitemap">
-       <input type="file" name="octopus_ai_sitemap_file[]" accept=".xml" multiple required>
-        <?php submit_button('Upload sitemap.xml', 'secondary'); ?>
-    </form>
+                <div class="upload-box">
+                    <h3>🗺️ Sitemap handmatig uploaden</h3>
+                    <p class="section-description">Gebruik dit als je een sitemap.xml lokaal wilt beheren in plaats van online op te halen.</p>
+                    <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" enctype="multipart/form-data">
+                        <?php wp_nonce_field('octopus_ai_upload_sitemap', 'octopus_ai_sitemap_nonce'); ?>
+                        <input type="hidden" name="action" value="octopus_ai_upload_sitemap">
+                        <input type="file" name="octopus_ai_sitemap_file[]" accept=".xml" multiple required>
+                        <?php submit_button('Upload sitemap.xml', 'secondary'); ?>
+                    </form>
+                </div>
+            </div>
 
-    <form method="post">
-        <input type="url" name="sitemap_url" value="<?php echo esc_attr(get_option('octopus_ai_sitemap_url', '')); ?>" style="width:400px;" placeholder="https://example.com/sitemap.xml" />
-        <?php submit_button('💾 Sitemap opslaan'); ?>
-    </form>
+            <div class="source-mode-panel <?php echo $source_strategy === 'sitemap_online' ? 'is-active' : ''; ?>" data-mode="sitemap_online">
+                <div class="upload-box">
+                    <h3>🔗 Sitemap via URL</h3>
+                    <p class="section-description">Bewaar een sitemap-URL die automatisch gecrawld en gechunkt wordt.</p>
+                    <form method="post">
+                        <input type="url" name="sitemap_url" value="<?php echo esc_attr($saved_sitemap_url); ?>" style="width:400px;" placeholder="https://example.com/sitemap.xml" required />
+                        <?php submit_button('💾 Sitemap opslaan'); ?>
+                    </form>
+                </div>
 
-    <form method="post" action="<?php echo admin_url('admin-post.php'); ?>" style="margin-top:15px;">
-        <?php wp_nonce_field('octopus_ai_auto_sitemap', 'octopus_ai_auto_sitemap_nonce'); ?>
-        <input type="hidden" name="action" value="octopus_ai_auto_fetch_sitemap">
-        <input type="url" name="octopus_ai_site_url" style="width:400px;" placeholder="https://example.com" required />
-        <?php submit_button('🔎 Zoek sitemap automatisch', 'secondary'); ?>
-    </form>
-</div>
+                <div class="upload-box">
+                    <h3>🔎 Zoek sitemap automatisch</h3>
+                    <p class="section-description">Geef een domein op. De crawler zoekt naar bekende sitemap-bestandsnamen en verwerkt ze meteen.</p>
+                    <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                        <?php wp_nonce_field('octopus_ai_auto_sitemap', 'octopus_ai_auto_sitemap_nonce'); ?>
+                        <input type="hidden" name="action" value="octopus_ai_auto_fetch_sitemap">
+                        <input type="url" name="octopus_ai_site_url" style="width:400px;" placeholder="https://example.com" required />
+                        <?php submit_button('🔎 Zoek sitemap automatisch', 'secondary'); ?>
+                    </form>
+                    <?php if (file_exists($sitemap_path)) : ?>
+                        <p style="margin-top:10px;"><strong>📄 Lokaal opgeslagen sitemap:</strong> <a href="<?php echo esc_url($upload_url . 'sitemap.xml'); ?>" target="_blank">Bekijk sitemap.xml</a></p>
+                    <?php endif; ?>
+                </div>
 
+                <div class="upload-box">
+                    <h3>🧪 Sitemap-voorbeeld</h3>
+                    <?php if (isset($_GET['sitemap_debug'])) : ?>
+                        <?php $urls = $parser->getUrlsFromSitemap(); ?>
+                        <p><strong><?php echo intval(count($urls)); ?> URL(s)</strong> gevonden in de sitemap.</p>
+                        <ul>
+                            <?php foreach (array_slice($urls, 0, 10) as $url_item) : ?>
+                                <li><a href="<?php echo esc_url($url_item); ?>" target="_blank"><?php echo esc_html($url_item); ?></a></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php else : ?>
+                        <p class="description">Toon een voorbeeld van de eerste gevonden URL's om te controleren of de juiste sitemap wordt gelezen.</p>
+                    <?php endif; ?>
+                    <p><a href="<?php echo esc_url(add_query_arg('sitemap_debug', '1')); ?>" class="button">🔍 Toon sitemap-URL’s</a></p>
+                </div>
+            </div>
 
-<?php
-// ✅ Save externe URL
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sitemap_url'])) {
-    update_option('octopus_ai_sitemap_url', esc_url_raw($_POST['sitemap_url']));
-    echo '<div class="notice notice-success is-dismissible"><p>Sitemap-URL opgeslagen.</p></div>';
-}
+            <div class="source-mode-panel <?php echo $source_strategy === 'live_manual' ? 'is-active' : ''; ?>" data-mode="live_manual">
+                <div class="upload-box">
+                    <h3>⚡ Live handleiding modus</h3>
+                    <p>De chatbot haalt voor elke vraag rechtstreeks tekst op uit de Octopus-handleiding. Het antwoord bevat altijd een exacte link naar de gebruikte pagina.</p>
+                    <ul style="list-style:disc;padding-left:20px;">
+                        <li>Controleer dat de basis-URL's hierboven juist ingesteld zijn.</li>
+                        <li>Gebruik de velden voor voorkeurspagina's om belangrijke topics te boosten.</li>
+                        <li>Omdat enkel live data gebruikt wordt, hoef je geen PDF's of sitemaps te beheren.</li>
+                    </ul>
+                </div>
+            </div>
 
-$sitemap_path = $upload_path . 'sitemap.xml';
-if (file_exists($sitemap_path)) {
-    echo '<p><strong>📄 Huidige sitemap:</strong> <a href="' . esc_url($upload_url . 'sitemap.xml') . '" target="_blank">Bekijk sitemap.xml</a></p>';
-}
+            <div class="source-mode-panel <?php echo $shared_active ? 'is-active' : ''; ?>" data-mode-group="manual_upload,sitemap_online">
+                <h3>🗂️ Geüploade bestanden</h3>
+                <?php if (isset($_GET['bulk_delete'])) : ?>
+                    <div class="notice notice-success is-dismissible"><p><?php echo intval($_GET['bulk_delete']); ?> bestand(en) succesvol verwijderd.</p></div>
+                <?php endif; ?>
+                <?php if (file_exists($upload_path)) : ?>
+                    <?php $files = glob($upload_path . '*'); ?>
+                    <?php if ($files) : ?>
+                        <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                            <?php wp_nonce_field('octopus_ai_bulk_delete', 'octopus_ai_bulk_delete_nonce'); ?>
+                            <input type="hidden" name="action" value="octopus_ai_bulk_delete">
+                            <ul>
+                                <?php foreach ($files as $file) :
+                                    $filename = basename($file);
+                                    $delete_url = wp_nonce_url(admin_url('admin-post.php?action=octopus_ai_delete_file&file=' . urlencode($filename)), 'octopus_ai_delete_file'); ?>
+                                    <li>
+                                        <label>
+                                            <input type="checkbox" name="octopus_ai_files[]" value="<?php echo esc_attr($filename); ?>">
+                                            <a href="<?php echo esc_url($upload_url . $filename); ?>" target="_blank"><?php echo esc_html($filename); ?></a>
+                                        </label>
+                                        <a href="<?php echo esc_url($delete_url); ?>" style="color:red;margin-left:10px;" onclick="return confirm('Weet je zeker dat je dit bestand wilt verwijderen?');">Verwijderen</a>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                            <p><input type="submit" class="button button-secondary" value="Geselecteerde bestanden verwijderen" onclick="return confirm('Weet je zeker dat je deze bestanden wilt verwijderen?');"></p>
+                        </form>
+                    <?php else : ?>
+                        <p>Er zijn nog geen bestanden geüpload.</p>
+                    <?php endif; ?>
+                <?php else : ?>
+                    <p>Er zijn nog geen bestanden geüpload.</p>
+                <?php endif; ?>
+            </div>
 
-require_once plugin_dir_path(__FILE__) . '../includes/sitemap-parser.php';
-$parser = new \OctopusAI\Includes\SitemapParser();
+            <div class="source-mode-panel <?php echo $shared_active ? 'is-active' : ''; ?>" data-mode-group="manual_upload,sitemap_online">
+                <h3>🧾 Geüploade sitemap-bestanden</h3>
+                <?php if (isset($_GET['sitemaps_deleted'])) : ?>
+                    <div class="notice notice-success is-dismissible"><p><?php echo intval($_GET['sitemaps_deleted']); ?> sitemap-bestand(en) verwijderd.</p></div>
+                <?php endif; ?>
+                <?php if ($sitemaps) : ?>
+                    <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                        <?php wp_nonce_field('octopus_ai_delete_sitemaps'); ?>
+                        <input type="hidden" name="action" value="octopus_ai_delete_sitemaps">
+                        <ul style="max-height:250px;overflow:auto;border:1px solid #ccc;padding:10px;background:#fff;">
+                            <?php foreach ($sitemaps as $file) :
+                                $filename = basename($file); ?>
+                                <li>
+                                    <label>
+                                        <input type="checkbox" name="sitemap_files[]" value="<?php echo esc_attr($filename); ?>">
+                                        <a href="<?php echo esc_url($sitemap_url_base . $filename); ?>" target="_blank"><?php echo esc_html($filename); ?></a>
+                                    </label>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                        <p style="margin-top:10px;">
+                            <input type="submit" class="button button-secondary" value="🗑️ Verwijder geselecteerde sitemaps" onclick="return confirm('Weet je zeker dat je deze sitemap-bestanden wilt verwijderen?');">
+                        </p>
+                    </form>
+                <?php else : ?>
+                    <p><em>Er zijn momenteel geen sitemap-bestanden geüpload.</em></p>
+                <?php endif; ?>
+            </div>
 
-if (isset($_GET['sitemap_debug'])) {
-    $urls = $parser->getUrlsFromSitemap();
-    echo '<p><strong>' . count($urls) . ' URL(s)</strong> gevonden in de sitemap.</p>';
-    echo '<ul>';
-    foreach (array_slice($urls, 0, 10) as $url) {
-        echo '<li><a href="' . esc_url($url) . '" target="_blank">' . esc_html($url) . '</a></li>';
-    }
-    echo '</ul>';
-}
-
-echo '<p><a href="' . esc_url(add_query_arg('sitemap_debug', '1')) . '" class="button">🔍 Toon sitemap-URL’s</a></p>';
-?>
-
-<hr>
-
-<h2>🧾 Geüploade sitemap-bestanden</h2>
-
-<?php
-$upload_dir = wp_upload_dir();
-$sitemap_dir = trailingslashit($upload_dir['basedir']) . 'octopus-chatbot/';
-$sitemap_url = trailingslashit($upload_dir['baseurl']) . 'octopus-chatbot/';
-
-$sitemaps = glob($sitemap_dir . '*.xml');
-
-if (isset($_GET['sitemaps_deleted'])) {
-    echo '<div class="notice notice-success is-dismissible"><p>' . intval($_GET['sitemaps_deleted']) . ' sitemap-bestand(en) verwijderd.</p></div>';
-}
-
-if ($sitemaps):
-?>
-    <form method="post" action="<?php echo admin_url('admin-post.php'); ?>">
-        <?php wp_nonce_field('octopus_ai_delete_sitemaps'); ?>
-        <input type="hidden" name="action" value="octopus_ai_delete_sitemaps">
-        <ul style="max-height:250px;overflow:auto;border:1px solid #ccc;padding:10px;background:#fff;">
-            <?php foreach ($sitemaps as $file): 
-                $filename = basename($file); ?>
-                <li>
-                    <label>
-                        <input type="checkbox" name="sitemap_files[]" value="<?php echo esc_attr($filename); ?>">
-                        <a href="<?php echo esc_url($sitemap_url . $filename); ?>" target="_blank"><?php echo esc_html($filename); ?></a>
-                    </label>
-                </li>
-            <?php endforeach; ?>
-        </ul>
-        <p style="margin-top:10px;">
-            <input type="submit" class="button button-secondary" value="🗑️ Verwijder geselecteerde sitemaps" onclick="return confirm('Weet je zeker dat je deze sitemap-bestanden wilt verwijderen?');">
-        </p>
-    </form>
-<?php else: ?>
-    <p><em>Er zijn momenteel geen sitemap-bestanden geüpload.</em></p>
-<?php endif; ?>
-
-
-<h2>🧹 Sitemap chunks beheren</h2>
-
-<?php
-$chunk_dir = trailingslashit($upload_dir['basedir']) . 'octopus-ai-chunks/';
-$chunk_url = trailingslashit($upload_dir['baseurl']) . 'octopus-ai-chunks/';
-
-if (isset($_GET['chunks_deleted'])) {
-    echo '<div class="notice notice-success is-dismissible"><p>' . intval($_GET['chunks_deleted']) . ' chunk(s) verwijderd.</p></div>';
-}
-if (isset($_GET['chunks_cleared'])) {
-    echo '<div class="notice notice-success is-dismissible"><p>Alle sitemap chunks verwijderd.</p></div>';
-}
-
-if (file_exists($chunk_dir)) {
-    $chunk_files = glob($chunk_dir . 'sitemap_*.json');
-    if ($chunk_files): ?>
-        <form method="post" action="<?php echo admin_url('admin-post.php'); ?>">
-            <?php wp_nonce_field('octopus_ai_delete_chunks'); ?>
-            <input type="hidden" name="action" value="octopus_ai_delete_chunks">
-            <ul style="max-height:250px;overflow:auto;border:1px solid #ccc;padding:10px;background:#fff;">
-                <?php foreach ($chunk_files as $file): 
-                    $filename = basename($file); ?>
-                    <li>
-                        <label>
-                            <input type="checkbox" name="chunk_files[]" value="<?php echo esc_attr($filename); ?>">
-                            <a href="<?php echo esc_url($chunk_url . $filename); ?>" target="_blank"><?php echo esc_html($filename); ?></a>
-                        </label>
-                    </li>
-                <?php endforeach; ?>
-            </ul>
-            <p style="margin-top:10px;">
-                <input type="submit" class="button button-secondary" value="🗑️ Geselecteerde chunks verwijderen" onclick="return confirm('Weet je zeker dat je deze bestanden wilt verwijderen?');">
-            </p>
-        </form>
-
-        <!-- Alles verwijderen -->
-        <form method="post" action="<?php echo admin_url('admin-post.php'); ?>" style="margin-top:10px;">
-            <?php wp_nonce_field('octopus_ai_clear_all_chunks'); ?>
-            <input type="hidden" name="action" value="octopus_ai_clear_all_chunks">
-            <?php submit_button('🧨 Verwijder ALLE sitemap chunks', 'delete', '', false); ?>
-        </form>
-
-    <?php else: ?>
-        <p><em>Er zijn momenteel geen sitemap chunks opgeslagen.</em></p>
-    <?php endif;
-} else {
-    echo '<p><em>De chunks-folder bestaat nog niet.</em></p>';
-}
-?>
-
+            <div class="source-mode-panel <?php echo $shared_active ? 'is-active' : ''; ?>" data-mode-group="manual_upload,sitemap_online">
+                <h3>🧹 Sitemap chunks beheren</h3>
+                <?php if (isset($_GET['chunks_deleted'])) : ?>
+                    <div class="notice notice-success is-dismissible"><p><?php echo intval($_GET['chunks_deleted']); ?> chunk(s) verwijderd.</p></div>
+                <?php endif; ?>
+                <?php if (isset($_GET['chunks_cleared'])) : ?>
+                    <div class="notice notice-success is-dismissible"><p>Alle sitemap chunks verwijderd.</p></div>
+                <?php endif; ?>
+                <?php if (file_exists($chunk_dir)) : ?>
+                    <?php $chunk_files = glob($chunk_dir . 'sitemap_*.json'); ?>
+                    <?php if ($chunk_files) : ?>
+                        <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                            <?php wp_nonce_field('octopus_ai_delete_chunks'); ?>
+                            <input type="hidden" name="action" value="octopus_ai_delete_chunks">
+                            <ul style="max-height:250px;overflow:auto;border:1px solid #ccc;padding:10px;background:#fff;">
+                                <?php foreach ($chunk_files as $file) :
+                                    $filename = basename($file); ?>
+                                    <li>
+                                        <label>
+                                            <input type="checkbox" name="chunk_files[]" value="<?php echo esc_attr($filename); ?>">
+                                            <a href="<?php echo esc_url($chunk_url . $filename); ?>" target="_blank"><?php echo esc_html($filename); ?></a>
+                                        </label>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                            <p style="margin-top:10px;">
+                                <input type="submit" class="button button-secondary" value="🗑️ Geselecteerde chunks verwijderen" onclick="return confirm('Weet je zeker dat je deze bestanden wilt verwijderen?');">
+                            </p>
+                        </form>
+                        <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="margin-top:10px;">
+                            <?php wp_nonce_field('octopus_ai_clear_all_chunks'); ?>
+                            <input type="hidden" name="action" value="octopus_ai_clear_all_chunks">
+                            <?php submit_button('🧨 Verwijder ALLE sitemap chunks', 'delete', '', false); ?>
+                        </form>
+                    <?php else : ?>
+                        <p><em>Er zijn momenteel geen sitemap chunks opgeslagen.</em></p>
+                    <?php endif; ?>
+                <?php else : ?>
+                    <p><em>De chunks-folder bestaat nog niet.</em></p>
+                <?php endif; ?>
+            </div>
         </div>
-
-
-<hr>
-
-<script>
-document.addEventListener('DOMContentLoaded', function () {
-    const url = new URL(window.location);
-    const paramsToRemove = ['upload', 'delete', 'bulk_delete', 'chunks_deleted', 'chunks_cleared', 'sitemap_debug', 'pages'];
-
-    let shouldUpdate = false;
-    for (const param of paramsToRemove) {
-        if (url.searchParams.has(param)) {
-            url.searchParams.delete(param);
-            shouldUpdate = true;
-        }
-    }
-
-    if (shouldUpdate) {
-        window.history.replaceState({}, document.title, url.pathname + url.search);
-    }
-});
-</script>
-<script>
-function toggleSection(header) {
-    const content = header.nextElementSibling;
-    content.classList.toggle('hidden');
-    header.classList.toggle('collapsed');
-}
-</script>
-
-
     </div>
 
     <script>
-        document.getElementById('octopus_ai_display_mode').addEventListener('change', function() {
-            const row = document.getElementById('octopus_ai_page_selector_row');
-            row.style.display = this.value === 'selected' ? '' : 'none';
-        });
-    </script>
-<?php if (isset($_GET['upload']) || isset($_GET['sitemap_debug'])): ?>
-<script>
     document.addEventListener('DOMContentLoaded', function () {
-        const el = document.getElementById('sitemap-zone');
-        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        const url = new URL(window.location);
+        const paramsToRemove = ['upload', 'delete', 'bulk_delete', 'chunks_deleted', 'chunks_cleared', 'sitemap_debug', 'pages'];
+
+        let shouldUpdate = false;
+        for (const param of paramsToRemove) {
+            if (url.searchParams.has(param)) {
+                url.searchParams.delete(param);
+                shouldUpdate = true;
+            }
+        }
+
+        if (shouldUpdate) {
+            window.history.replaceState({}, document.title, url.pathname + url.search);
+        }
     });
-</script>
-<?php endif; ?>
+    </script>
+    <script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const displayMode = document.getElementById('octopus_ai_display_mode');
+        const pageRow = document.getElementById('octopus_ai_page_selector_row');
+        if (displayMode && pageRow) {
+            displayMode.addEventListener('change', function () {
+                pageRow.style.display = this.value === 'selected' ? '' : 'none';
+            });
+        }
+
+        const strategyInputs = document.querySelectorAll('input[name="octopus_ai_source_strategy"]');
+        const cards = document.querySelectorAll('.source-mode-card');
+        const panels = document.querySelectorAll('.source-mode-panel[data-mode]');
+        const groupedPanels = document.querySelectorAll('.source-mode-panel[data-mode-group]');
+        const manualModeField = document.getElementById('octopus_ai_manual_mode_hidden');
+
+        function activateStrategy(value) {
+            cards.forEach(card => {
+                if (card.dataset.target) {
+                    card.classList.toggle('is-active', card.dataset.target === value);
+                }
+            });
+            panels.forEach(panel => {
+                panel.classList.toggle('is-active', panel.dataset.mode === value);
+            });
+            groupedPanels.forEach(panel => {
+                const list = panel.dataset.modeGroup ? panel.dataset.modeGroup.split(',') : [];
+                panel.classList.toggle('is-active', list.includes(value));
+            });
+            if (manualModeField) {
+                manualModeField.value = value === 'live_manual' ? 'live' : 'local';
+            }
+        }
+
+        strategyInputs.forEach(input => {
+            input.addEventListener('change', () => activateStrategy(input.value));
+        });
+
+        const initial = document.querySelector('input[name="octopus_ai_source_strategy"]:checked');
+        if (initial) {
+            activateStrategy(initial.value);
+        }
+    });
+    </script>
 <?php }
-
-
-

--- a/includes/helpers/live-manual.php
+++ b/includes/helpers/live-manual.php
@@ -8,6 +8,15 @@ if (!defined('ABSPATH')) exit;
  */
 function octopus_ai_get_manual_mode()
 {
+    $strategy = get_option('octopus_ai_source_strategy', '');
+    if ($strategy === 'live_manual') {
+        return 'live';
+    }
+
+    if (in_array($strategy, ['manual_upload', 'sitemap_online'], true)) {
+        return 'local';
+    }
+
     $mode = get_option('octopus_ai_manual_mode', 'hybrid');
     $allowed = ['local', 'hybrid', 'live'];
 


### PR DESCRIPTION
## Summary
- add a dedicated source strategy option with sanitization and refresh the admin UI with card-based selectors, context-sensitive panels, and clearer sitemap management tools
- ensure the selected strategy drives runtime behavior by isolating chunk usage versus live manual fetching and updating the live helper to respect the new setting

## Testing
- `php -l admin/settings-page.php`
- `php -l includes/api-handler.php`
- `php -l includes/helpers/live-manual.php`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691ad9e1d8f4833295787c1773afd181)